### PR TITLE
Feature: Input fields decoration

### DIFF
--- a/lib/src/ui/form_components/entry.dart
+++ b/lib/src/ui/form_components/entry.dart
@@ -23,6 +23,7 @@ export "input_field/models/coordinate_field.dart" show D2GeometryValue;
 export "input_field/models/date_input_field.dart" show D2DateInputFieldConfig;
 export "input_field/models/date_range_input_field.dart"
     show D2DateRangeInputFieldConfig;
+export "input_field/models/input_decoration_container.dart";
 export "input_field/models/input_field_option.dart" show D2InputFieldOption;
 export "input_field/models/input_field_type_enum.dart" show D2InputFieldType;
 export "input_field/models/number_input_field.dart"
@@ -32,8 +33,7 @@ export "input_field/models/org_unit_input_field.dart"
 export "input_field/models/select_input_field.dart"
     show D2SelectInputFieldConfig;
 export "input_field/models/text_input_field.dart" show D2TextInputFieldConfig;
-export "input_field/models/true_only_input_field.dart"
-    show D2TrueOnlyInputFieldConfig;
+export "input_field/models/true_only_input_field.dart";
 export "state/aggregate/data_set_controller.dart"
     show D2DataSetStateFormController;
 export "state/form_state.dart" show D2FormController;

--- a/lib/src/ui/form_components/input_field/components/age_input/age_input.dart
+++ b/lib/src/ui/form_components/input_field/components/age_input/age_input.dart
@@ -20,7 +20,8 @@ class AgeInputField extends BaseStatefulInput<D2AgeInputFieldConfig, String> {
       required super.onChange,
       required super.color,
       super.disabled,
-      super.value});
+      super.value,
+      required super.decoration});
 
   @override
   State<StatefulWidget> createState() {
@@ -107,24 +108,26 @@ class AgeInputFieldState extends BaseStatefulInputState<AgeInputField> {
 
     if (selectedView == D2AgeInputFieldView.date) {
       return DateInput(
-          disabled: widget.disabled,
-          value: widget.value,
-          input: D2DateInputFieldConfig(
-              label: input.label,
-              type: D2InputFieldType.date,
-              allowFutureDates: false,
-              mandatory: input.mandatory,
-              name: input.name,
-              clearable: input.clearable,
-              icon: input.icon,
-              legends: input.legends,
-              svgIconAsset: input.svgIconAsset),
-          onChange: (String? value) {
-            if (value != null) {
-              widget.onChange(DateTime.tryParse(value)?.format(DATE_FORMAT));
-            }
-          },
-          color: widget.color);
+        disabled: widget.disabled,
+        value: widget.value,
+        input: D2DateInputFieldConfig(
+            label: input.label,
+            type: D2InputFieldType.date,
+            allowFutureDates: false,
+            mandatory: input.mandatory,
+            name: input.name,
+            clearable: input.clearable,
+            icon: input.icon,
+            legends: input.legends,
+            svgIconAsset: input.svgIconAsset),
+        onChange: (String? value) {
+          if (value != null) {
+            widget.onChange(DateTime.tryParse(value)?.format(DATE_FORMAT));
+          }
+        },
+        color: widget.color,
+        decoration: widget.decoration,
+      );
     }
 
     if (selectedView == D2AgeInputFieldView.age) {

--- a/lib/src/ui/form_components/input_field/components/base_input.dart
+++ b/lib/src/ui/form_components/input_field/components/base_input.dart
@@ -1,4 +1,5 @@
 import 'package:dhis2_flutter_toolkit/src/ui/form_components/input_field/models/base_input_field.dart';
+import 'package:dhis2_flutter_toolkit/src/ui/form_components/input_field/models/input_decoration_container.dart';
 import 'package:flutter/material.dart';
 
 typedef OnChange<T> = void Function(T);
@@ -10,6 +11,7 @@ abstract class BaseStatelessInput<FieldType extends D2BaseInputFieldConfig,
   final ValueType? value;
   final OnChange<ValueType?> onChange;
   final bool disabled;
+  final D2InputDecoration decoration;
 
   final BoxConstraints iconConstraints = const BoxConstraints(
       maxHeight: 45, minHeight: 42, maxWidth: 45, minWidth: 42);
@@ -20,6 +22,7 @@ abstract class BaseStatelessInput<FieldType extends D2BaseInputFieldConfig,
     required this.onChange,
     required this.color,
     this.disabled = false,
+    required this.decoration,
     this.value,
   });
 }
@@ -31,6 +34,7 @@ abstract class BaseStatefulInput<FieldType extends D2BaseInputFieldConfig,
   final ValueType? value;
   final OnChange<ValueType?> onChange;
   final bool disabled;
+  final D2InputDecoration decoration;
 
   const BaseStatefulInput({
     super.key,
@@ -38,12 +42,18 @@ abstract class BaseStatefulInput<FieldType extends D2BaseInputFieldConfig,
     required this.onChange,
     required this.color,
     this.disabled = false,
+    required this.decoration,
     this.value,
   });
 }
 
 abstract class BaseStatefulInputState<T extends BaseStatefulInput>
     extends State<T> {
-  final BoxConstraints iconConstraints = const BoxConstraints(
-      maxHeight: 45, minHeight: 42, maxWidth: 45, minWidth: 42);
+  late BoxConstraints iconConstraints;
+
+  @override
+  void initState() {
+    iconConstraints = widget.decoration.inputIconDecoration.iconConstraints;
+    super.initState();
+  }
 }

--- a/lib/src/ui/form_components/input_field/components/boolean_input.dart
+++ b/lib/src/ui/form_components/input_field/components/boolean_input.dart
@@ -13,6 +13,7 @@ class BooleanInput
     required super.input,
     required super.color,
     required super.onChange,
+    required super.decoration,
   });
 
   @override
@@ -45,7 +46,7 @@ class BooleanInput
                   style: const TextStyle().copyWith(
                     fontWeight: FontWeight.w400,
                     fontSize: 16.0,
-                    color: const Color(0xFF1D2B36),
+                    color: decoration.colorScheme.text,
                   ),
                 ),
               ],

--- a/lib/src/ui/form_components/input_field/components/boolean_input.dart
+++ b/lib/src/ui/form_components/input_field/components/boolean_input.dart
@@ -31,10 +31,14 @@ class BooleanInput
               children: [
                 Radio(
                   toggleable: !disabled,
+                  overlayColor:
+                      MaterialStatePropertyAll(decoration.colorScheme.text),
                   fillColor: MaterialStatePropertyAll(
-                    "$value" == option.code ? color : const Color(0xFF94A0B1),
+                    "$value" == option.code
+                        ? decoration.colorScheme.active
+                        : decoration.colorScheme.inactive,
                   ),
-                  activeColor: color,
+                  activeColor: decoration.colorScheme.active,
                   value: option.code,
                   groupValue: value,
                   onChanged: disabled

--- a/lib/src/ui/form_components/input_field/components/coordinate_input/coordinate_input.dart
+++ b/lib/src/ui/form_components/input_field/components/coordinate_input/coordinate_input.dart
@@ -36,15 +36,19 @@ class CoordinateInputState extends BaseStatefulInputState<CoordinateInput> {
     try {
       Position position = await determinePosition();
       onChange(D2GeometryValue(position.latitude, position.longitude));
-      setState(() {
-        _loadingLocation = false;
-        error = null;
-      });
+      if (mounted) {
+        setState(() {
+          _loadingLocation = false;
+          error = null;
+        });
+      }
     } catch (e) {
-      setState(() {
-        error = e.toString();
-        _loadingLocation = false;
-      });
+      if (mounted) {
+        setState(() {
+          error = e.toString();
+          _loadingLocation = false;
+        });
+      }
     }
   }
 
@@ -52,7 +56,7 @@ class CoordinateInputState extends BaseStatefulInputState<CoordinateInput> {
   void initState() {
     controller = TextEditingController(text: widget.value?.toString());
     super.initState();
-    if(widget.input.enableAutoLocation && widget.value == null) {
+    if (widget.input.enableAutoLocation && widget.value == null) {
       onGetCurrentLocation();
     }
   }

--- a/lib/src/ui/form_components/input_field/components/coordinate_input/coordinate_input.dart
+++ b/lib/src/ui/form_components/input_field/components/coordinate_input/coordinate_input.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
+
 import '../../models/coordinate_field.dart';
 import '../../utils/location.dart';
 import '../base_input.dart';
@@ -14,7 +15,8 @@ class CoordinateInput
       required super.onChange,
       required super.color,
       super.disabled,
-      super.value});
+      super.value,
+      required super.decoration});
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/src/ui/form_components/input_field/components/date_input.dart
+++ b/lib/src/ui/form_components/input_field/components/date_input.dart
@@ -12,7 +12,8 @@ class DateInput extends BaseStatelessInput<D2DateInputFieldConfig, String> {
       required super.input,
       required super.onChange,
       required super.color,
-      super.value});
+      super.value,
+      required super.decoration});
 
   void onOpenDateSelection(context) async {
     DateTime? selectedDateTime = await showDatePicker(

--- a/lib/src/ui/form_components/input_field/components/date_range_input.dart
+++ b/lib/src/ui/form_components/input_field/components/date_range_input.dart
@@ -13,7 +13,8 @@ class DateRangeInput
       required super.input,
       required super.onChange,
       required super.color,
-      super.value});
+      super.value,
+      required super.decoration});
 
   void onOpenDateSelection(context) async {
     DateTimeRange? selectedDateTime = await showDateRangePicker(

--- a/lib/src/ui/form_components/input_field/components/org_unit_input/org_unit_input.dart
+++ b/lib/src/ui/form_components/input_field/components/org_unit_input/org_unit_input.dart
@@ -18,6 +18,7 @@ class OrgUnitInput
     required super.color,
     required super.onChange,
     this.maxLines = 1,
+    required super.decoration,
   });
 
   @override

--- a/lib/src/ui/form_components/input_field/components/radio_input.dart
+++ b/lib/src/ui/form_components/input_field/components/radio_input.dart
@@ -12,6 +12,7 @@ class RadioInput extends BaseStatelessInput<D2SelectInputFieldConfig, String> {
     required super.input,
     required super.color,
     required super.onChange,
+    required super.decoration,
   });
 
   @override
@@ -22,7 +23,6 @@ class RadioInput extends BaseStatelessInput<D2SelectInputFieldConfig, String> {
       child: Wrap(
         direction: Axis.horizontal,
         children: input.options!.map((D2InputFieldOption option) {
-          bool isSelected = option.code == value;
           return Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -30,17 +30,16 @@ class RadioInput extends BaseStatelessInput<D2SelectInputFieldConfig, String> {
                 value: option.code,
                 groupValue: value,
                 onChanged: disabled ? null : onChange,
-                activeColor: disabled ? Colors.grey : color,
+                activeColor: disabled
+                    ? decoration.colorScheme.disabled
+                    : decoration.colorScheme.active,
               ),
               Text(
                 option.name,
                 style: TextStyle(
-                  color: disabled
-                      ? Colors.grey
-                      : isSelected
-                          ? color
-                          : null,
-                ),
+                    color: disabled
+                        ? decoration.colorScheme.disabled
+                        : decoration.colorScheme.text),
               ),
             ],
           );

--- a/lib/src/ui/form_components/input_field/components/select_input.dart
+++ b/lib/src/ui/form_components/input_field/components/select_input.dart
@@ -15,6 +15,7 @@ class SelectInput extends BaseStatelessInput<D2SelectInputFieldConfig, String> {
     required super.input,
     required super.color,
     required super.onChange,
+    required super.decoration,
   });
 
   @override
@@ -48,7 +49,7 @@ class SelectInput extends BaseStatelessInput<D2SelectInputFieldConfig, String> {
               ))
           .toList(),
       value: valueOption,
-      focusColor: color,
+      focusColor: decoration.colorScheme.active,
       items: options,
       iconDisabledColor: Colors.grey,
       icon: Transform.rotate(

--- a/lib/src/ui/form_components/input_field/components/text_input.dart
+++ b/lib/src/ui/form_components/input_field/components/text_input.dart
@@ -24,6 +24,7 @@ class TextInput extends BaseStatefulInput<D2BaseInputFieldConfig, String> {
     required super.color,
     required super.onChange,
     this.maxLines = 1,
+    required super.decoration,
   });
 
   @override
@@ -53,15 +54,16 @@ class TextInputState extends BaseStatefulInputState<TextInput> {
   Widget build(BuildContext context) {
     return TextFormField(
       controller: controller,
-      cursorColor: widget.color,
+      cursorColor: widget.decoration.colorScheme.active,
       enabled: !widget.disabled,
       onChanged: (String? value) {
         widget.onChange(value);
       },
       maxLines: widget.maxLines,
       keyboardType: widget.textInputType,
-      style: const TextStyle(
+      style: TextStyle(
         fontSize: 14,
+        color: widget.decoration.colorScheme.text,
         fontWeight: FontWeight.w500,
       ),
       textInputAction: TextInputAction.done,

--- a/lib/src/ui/form_components/input_field/components/true_only_input.dart
+++ b/lib/src/ui/form_components/input_field/components/true_only_input.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import '../models/true_only_input_field.dart';
 import 'base_input.dart';
 
-class TrueOnlyInput extends BaseStatelessInput<D2TrueOnlyInputFieldConfig, String> {
+class TrueOnlyInput
+    extends BaseStatelessInput<D2TrueOnlyInputFieldConfig, String> {
   const TrueOnlyInput({
     super.key,
     super.value,
@@ -11,6 +12,7 @@ class TrueOnlyInput extends BaseStatelessInput<D2TrueOnlyInputFieldConfig, Strin
     required super.input,
     required super.color,
     required super.onChange,
+    required super.decoration,
   });
 
   bool isSelected() {
@@ -24,18 +26,27 @@ class TrueOnlyInput extends BaseStatelessInput<D2TrueOnlyInputFieldConfig, Strin
       alignment: Alignment.centerLeft,
       margin: const EdgeInsets.symmetric(),
       child: Switch(
-        activeTrackColor: color,
-        inactiveTrackColor: Colors.white,
+        activeTrackColor: input.colorScheme?.activeTrackColor ?? color,
+        inactiveTrackColor:
+            input.colorScheme?.inactiveTrackColor ?? Colors.white,
         trackOutlineColor: MaterialStatePropertyAll(
-          isSelected() ? color : const Color(0xFF94A0B1),
+          isSelected()
+              ? input.colorScheme?.activeTrackOutlineColor ?? color
+              : input.colorScheme?.inactiveTrackOutlineColor ??
+                  const Color(0xFF94A0B1),
         ),
         thumbColor: MaterialStatePropertyAll(
-          isSelected() ? Colors.white : const Color(0xFF94A0B1),
+          isSelected()
+              ? input.colorScheme?.activeThumbColor ?? Colors.white
+              : input.colorScheme?.inactiveThumbColor ??
+                  const Color(0xFF94A0B1),
         ),
         thumbIcon: MaterialStateProperty.all(
           Icon(
             isSelected() ? Icons.check : Icons.close,
-            color: isSelected() ? color : Colors.white,
+            color: isSelected()
+                ? input.colorScheme?.activeThumbIconColor ?? color
+                : input.colorScheme?.inactiveThumbIconColor ?? Colors.white,
           ),
         ),
         value: isSelected(),

--- a/lib/src/ui/form_components/input_field/form_controlled_field_container.dart
+++ b/lib/src/ui/form_components/input_field/form_controlled_field_container.dart
@@ -1,3 +1,4 @@
+import 'package:dhis2_flutter_toolkit/src/ui/form_components/input_field/models/input_decoration_container.dart';
 import 'package:flutter/material.dart';
 
 import '../state/field_state.dart';
@@ -10,11 +11,13 @@ class D2FormControlledInputField extends StatelessWidget {
   final Color? color;
   final D2FormController controller;
   final bool? disabled;
+  final D2InputDecoration? inputDecoration;
 
   const D2FormControlledInputField(
       {super.key,
       required this.input,
       this.disabled,
+      this.inputDecoration,
       required this.controller,
       required this.color});
 
@@ -27,6 +30,7 @@ class D2FormControlledInputField extends StatelessWidget {
           return Visibility(
             visible: !(fieldState.hidden ?? false),
             child: D2InputFieldContainer(
+              inputDecoration: inputDecoration,
               input: input,
               onChange: fieldState.onChange,
               color: color,

--- a/lib/src/ui/form_components/input_field/input_field_container.dart
+++ b/lib/src/ui/form_components/input_field/input_field_container.dart
@@ -1,3 +1,5 @@
+import 'package:dhis2_flutter_toolkit/src/ui/form_components/input_field/models/input_decoration_container.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'components/age_input/age_input.dart';
@@ -33,23 +35,24 @@ class D2InputFieldContainer extends StatelessWidget {
   final String? error;
   final String? warning;
   final bool disabled;
+  D2InputDecoration? inputDecoration;
 
-  const D2InputFieldContainer(
+  D2InputFieldContainer(
       {super.key,
       required this.input,
+      this.inputDecoration,
       this.value,
       required this.onChange,
       required this.color,
       this.error,
       this.disabled = false,
-      this.warning});
-
-  final BoxConstraints iconConstraints = const BoxConstraints(
-    maxHeight: 45.0,
-    minHeight: 42.0,
-    maxWidth: 45.0,
-    minWidth: 42.0,
-  );
+      this.warning}) {
+    inputDecoration ??=
+        D2InputDecoration.fromInput(input, color: color ?? Colors.blue);
+    if (kDebugMode) {
+      print(inputDecoration);
+    }
+  }
 
   void onClear() {
     onChange(null);
@@ -72,6 +75,7 @@ class D2InputFieldContainer extends StatelessWidget {
                 color: colorOverride,
                 onChange: onChange,
                 value: value,
+                decoration: inputDecoration!,
               )
             : SelectInput(
                 disabled: disabled,
@@ -79,6 +83,7 @@ class D2InputFieldContainer extends StatelessWidget {
                 color: colorOverride,
                 onChange: onChange,
                 value: value,
+                decoration: inputDecoration!,
               );
       }
       if (input is D2DateInputFieldConfig) {
@@ -88,6 +93,7 @@ class D2InputFieldContainer extends StatelessWidget {
           input: input as D2DateInputFieldConfig,
           color: colorOverride,
           onChange: onChange,
+          decoration: inputDecoration!,
         );
       }
       if (input is D2DateRangeInputFieldConfig) {
@@ -97,6 +103,7 @@ class D2InputFieldContainer extends StatelessWidget {
           input: input as D2DateRangeInputFieldConfig,
           color: colorOverride,
           onChange: onChange,
+          decoration: inputDecoration!,
         );
       }
       if (input is D2NumberInputFieldConfig) {
@@ -113,6 +120,7 @@ class D2InputFieldContainer extends StatelessWidget {
                 input: input,
                 value: value,
                 onChange: onChange,
+                decoration: inputDecoration!,
                 color: colorOverride);
           default:
             return TextInput(
@@ -122,6 +130,7 @@ class D2InputFieldContainer extends StatelessWidget {
                 input: input,
                 value: value,
                 onChange: onChange,
+                decoration: inputDecoration!,
                 color: colorOverride);
         }
       }
@@ -132,6 +141,7 @@ class D2InputFieldContainer extends StatelessWidget {
           case D2InputFieldType.email:
           case D2InputFieldType.url:
             return TextInput(
+              decoration: inputDecoration!,
               disabled: disabled,
               onChange: onChange,
               value: value,
@@ -155,6 +165,7 @@ class D2InputFieldContainer extends StatelessWidget {
               input: input,
               color: colorOverride,
               textInputType: TextInputType.text,
+              decoration: inputDecoration!,
             );
         }
       }
@@ -165,6 +176,7 @@ class D2InputFieldContainer extends StatelessWidget {
           value: value,
           input: input as D2BooleanInputFieldConfig,
           color: colorOverride,
+          decoration: inputDecoration!,
         );
       }
       if (input is D2TrueOnlyInputFieldConfig) {
@@ -174,15 +186,18 @@ class D2InputFieldContainer extends StatelessWidget {
           value: value,
           input: input as D2TrueOnlyInputFieldConfig,
           color: colorOverride,
+          decoration: inputDecoration!,
         );
       }
       if (input is D2OrgUnitInputFieldConfig) {
         return OrgUnitInput(
-            disabled: disabled,
-            value: value,
-            input: input as D2OrgUnitInputFieldConfig,
-            color: colorOverride,
-            onChange: onChange);
+          disabled: disabled,
+          value: value,
+          input: input as D2OrgUnitInputFieldConfig,
+          color: colorOverride,
+          onChange: onChange,
+          decoration: inputDecoration!,
+        );
       }
       if (input is D2GeometryInputConfig) {
         return CoordinateInput(
@@ -191,6 +206,7 @@ class D2InputFieldContainer extends StatelessWidget {
           value: value,
           input: input as D2GeometryInputConfig,
           color: colorOverride,
+          decoration: inputDecoration!,
         );
       }
       if (input is D2AgeInputFieldConfig) {
@@ -200,6 +216,7 @@ class D2InputFieldContainer extends StatelessWidget {
           color: colorOverride,
           value: value,
           disabled: disabled,
+          decoration: inputDecoration!,
         );
       }
 
@@ -210,6 +227,7 @@ class D2InputFieldContainer extends StatelessWidget {
         input: input,
         color: colorOverride,
         textInputType: TextInputType.text,
+        decoration: inputDecoration!,
       );
     }
 
@@ -217,12 +235,12 @@ class D2InputFieldContainer extends StatelessWidget {
       if (input.svgIconAsset != null || input.icon != null) {
         return Container(
           margin: const EdgeInsets.only(left: 16.0),
-          constraints: iconConstraints,
+          constraints: inputDecoration!.inputIconDecoration.iconConstraints,
           child: InputFieldIcon(
             backgroundColor: colorOverride,
             iconColor: colorOverride,
-            iconData: input.icon,
-            svgIcon: input.svgIconAsset,
+            iconData: inputDecoration!.inputIconDecoration.iconData,
+            svgIcon: inputDecoration!.inputIconDecoration.svgIconAsset,
           ),
         );
       } else {
@@ -233,34 +251,20 @@ class D2InputFieldContainer extends StatelessWidget {
     Widget getSuffix() {
       return Row(
         children: [
-          input.clearable && !disabled
-              ? IconButton(
-                  onPressed: onClear,
-                  icon: const Icon(Icons.clear),
-                )
-              : Container(),
+          Visibility(
+            visible: input.clearable && !disabled,
+            child: IconButton(
+              onPressed: onClear,
+              icon: const Icon(Icons.clear),
+            ),
+          )
         ],
       );
     }
 
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
-      decoration: BoxDecoration(
-        color: colorOverride.withOpacity(0.07),
-        border: Border(
-          left: BorderSide.none,
-          right: BorderSide.none,
-          top: BorderSide.none,
-          bottom: BorderSide(
-            width: 2,
-            color: colorOverride,
-          ),
-        ),
-        borderRadius: const BorderRadius.only(
-          topLeft: Radius.circular(4.0),
-          topRight: Radius.circular(4.0),
-        ),
-      ),
+      decoration: inputDecoration!.inputContainerDecoration,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/src/ui/form_components/input_field/input_field_container.dart
+++ b/lib/src/ui/form_components/input_field/input_field_container.dart
@@ -1,5 +1,4 @@
 import 'package:dhis2_flutter_toolkit/src/ui/form_components/input_field/models/input_decoration_container.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'components/age_input/age_input.dart';
@@ -47,11 +46,8 @@ class D2InputFieldContainer extends StatelessWidget {
       this.error,
       this.disabled = false,
       this.warning}) {
-    inputDecoration ??=
-        D2InputDecoration.fromInput(input, color: color ?? Colors.blue);
-    if (kDebugMode) {
-      print(inputDecoration);
-    }
+    inputDecoration ??= D2InputDecoration.fromInput(input,
+        color: color ?? Colors.blue, disabled: disabled);
   }
 
   void onClear() {
@@ -255,7 +251,10 @@ class D2InputFieldContainer extends StatelessWidget {
             visible: input.clearable && !disabled,
             child: IconButton(
               onPressed: onClear,
-              icon: const Icon(Icons.clear),
+              icon: Icon(
+                Icons.clear,
+                color: inputDecoration!.colorScheme.text,
+              ),
             ),
           )
         ],

--- a/lib/src/ui/form_components/input_field/models/input_decoration_container.dart
+++ b/lib/src/ui/form_components/input_field/models/input_decoration_container.dart
@@ -93,19 +93,21 @@ class D2InputDecoration {
             );
 
   D2InputDecoration.fromInput(D2BaseInputFieldConfig input,
-      {required Color color})
+      {required Color color, required bool disabled})
       : colorScheme = D2InputContainerColorScheme.fromMainColor(color),
         inputIconDecoration =
             D2InputIconDecoration.fromInput(input, color: color),
         inputContainerDecoration = BoxDecoration(
-          color: color.withOpacity(0.09),
+          color: disabled
+              ? Colors.grey.withOpacity(0.07)
+              : color.withOpacity(0.07),
           border: Border(
             left: BorderSide.none,
             right: BorderSide.none,
             top: BorderSide.none,
             bottom: BorderSide(
               width: 2,
-              color: color,
+              color: disabled ? Colors.grey : color,
             ),
           ),
           borderRadius: const BorderRadius.only(

--- a/lib/src/ui/form_components/input_field/models/input_decoration_container.dart
+++ b/lib/src/ui/form_components/input_field/models/input_decoration_container.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:dhis2_flutter_toolkit/dhis2_flutter_toolkit.dart';
+import 'package:flutter/material.dart';
+
+class D2InputContainerColorScheme {
+  Color error;
+  Color main;
+  Color text;
+  Color active;
+  Color inactive;
+  Color disabled;
+
+  D2InputContainerColorScheme.fromMainColor(this.main)
+      : text = Colors.black,
+        active = main,
+        disabled = Colors.grey,
+        error = Colors.red,
+        inactive = const Color(0xFF94A0B1);
+
+  D2InputContainerColorScheme(
+      {required this.error,
+      required this.main,
+      required this.text,
+      required this.active,
+      required this.inactive,
+      required this.disabled});
+
+  @override
+  String toString() {
+    return jsonEncode({
+      'active': active.toString(),
+      'main': main.toString(),
+      'text': text.toString(),
+      'disabled': disabled.toString(),
+      'error': error.toString()
+    });
+  }
+}
+
+class D2InputIconDecoration {
+  final BoxConstraints iconConstraints;
+  final Color backgroundColor;
+  final IconData? iconData;
+  final String? svgIconAsset;
+
+  D2InputIconDecoration.fromInput(D2BaseInputFieldConfig input, {Color? color})
+      : iconData = input.icon,
+        svgIconAsset = input.svgIconAsset,
+        iconConstraints = const BoxConstraints(
+          maxHeight: 45.0,
+          minHeight: 42.0,
+          maxWidth: 45.0,
+          minWidth: 42.0,
+        ),
+        backgroundColor = color ?? Colors.transparent;
+
+  @override
+  String toString() {
+    return jsonEncode({
+      'icon': svgIconAsset ?? iconData.toString(),
+      'backgroundColor': backgroundColor.toString(),
+      'constraints': iconConstraints.toString()
+    });
+  }
+}
+
+class D2InputDecoration {
+  final D2InputContainerColorScheme colorScheme;
+  final D2InputIconDecoration inputIconDecoration;
+  final BoxDecoration inputContainerDecoration;
+
+  D2InputDecoration(
+      {BoxDecoration? inputContainerDecoration,
+      required this.inputIconDecoration,
+      required this.colorScheme})
+      : inputContainerDecoration = inputContainerDecoration ??
+            BoxDecoration(
+              color: colorScheme.main.withOpacity(0.07),
+              border: Border(
+                left: BorderSide.none,
+                right: BorderSide.none,
+                top: BorderSide.none,
+                bottom: BorderSide(
+                  width: 2,
+                  color: colorScheme.main,
+                ),
+              ),
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(4.0),
+                topRight: Radius.circular(4.0),
+              ),
+            );
+
+  D2InputDecoration.fromInput(D2BaseInputFieldConfig input,
+      {required Color color})
+      : colorScheme = D2InputContainerColorScheme.fromMainColor(color),
+        inputIconDecoration =
+            D2InputIconDecoration.fromInput(input, color: color),
+        inputContainerDecoration = BoxDecoration(
+          color: color.withOpacity(0.09),
+          border: Border(
+            left: BorderSide.none,
+            right: BorderSide.none,
+            top: BorderSide.none,
+            bottom: BorderSide(
+              width: 2,
+              color: color,
+            ),
+          ),
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(4.0),
+            topRight: Radius.circular(4.0),
+          ),
+        );
+
+  @override
+  String toString() {
+    Map details = {
+      'colorScheme': colorScheme.toString(),
+      'icon': inputIconDecoration.toString(),
+      'container': inputContainerDecoration.toString()
+    };
+
+    return jsonEncode(details);
+  }
+}

--- a/lib/src/ui/form_components/input_field/models/true_only_input_field.dart
+++ b/lib/src/ui/form_components/input_field/models/true_only_input_field.dart
@@ -1,11 +1,37 @@
+import 'package:flutter/material.dart';
+
 import 'base_input_field.dart';
 
+class D2TrueOnlyInputFieldColorScheme {
+  Color activeTrackColor;
+  Color inactiveTrackColor;
+  Color activeTrackOutlineColor;
+  Color inactiveTrackOutlineColor;
+  Color activeThumbColor;
+  Color inactiveThumbColor;
+  Color activeThumbIconColor;
+  Color inactiveThumbIconColor;
+
+  D2TrueOnlyInputFieldColorScheme.fromMainColor(Color main)
+      : activeTrackColor = main,
+        inactiveTrackColor = Colors.white,
+        activeTrackOutlineColor = main,
+        inactiveTrackOutlineColor = const Color(0xFF94A0B1),
+        activeThumbColor = Colors.white,
+        inactiveThumbColor = const Color(0xFF94A0B1),
+        activeThumbIconColor = main,
+        inactiveThumbIconColor = Colors.white;
+}
+
 class D2TrueOnlyInputFieldConfig extends D2BaseInputFieldConfig {
+  D2TrueOnlyInputFieldColorScheme? colorScheme;
+
   D2TrueOnlyInputFieldConfig(
       {required super.label,
       required super.type,
       required super.name,
       required super.mandatory,
+      this.colorScheme,
       super.clearable,
       super.icon,
       super.legends,

--- a/lib/src/ui/form_components/input_field/utils/color.dart
+++ b/lib/src/ui/form_components/input_field/utils/color.dart
@@ -1,7 +1,9 @@
 import 'dart:ui';
 
-Color getTextColor(Color bgColor) {
+Color getTextColor(Color bgColor, {Color? darkColor, Color? lightColor}) {
   double brightness =
       (bgColor.red * 299 + bgColor.green * 587 + bgColor.blue * 114) / 1000;
-  return brightness > 128 ? const Color(0xFF000000) : const Color(0xFFFFFFFF);
+  return brightness > 128
+      ? darkColor ?? const Color(0xFF000000)
+      : lightColor ?? const Color(0xFFFFFFFF);
 }

--- a/lib/src/ui/form_components/utils/tracker_event_form_util.dart
+++ b/lib/src/ui/form_components/utils/tracker_event_form_util.dart
@@ -31,7 +31,8 @@ class D2TrackerEventFormUtil {
       return D2FormUtils.getFieldConfigFromDataItem(dataElement,
           mandatory: programStageDataElement.compulsory,
           allowFutureDates: programStageDataElement.allowFutureDate,
-          renderOptionsAsRadio: programStageDataElement.renderOptionsAsRadio);
+          renderOptionsAsRadio: programStageDataElement.renderOptionsAsRadio)
+        ..clearable = options.clearable;
     }).toList();
   }
 


### PR DESCRIPTION
This is an implementation that improves how you can style the input fields. By default, the input fields follow the provided standards. But in some cases the fields may need to be used in backgrounds/widgets that do not support the input styling

The `D2InputDecoration` class is introduced to help in fine-tuning the input color, icon, and box styling.