### PR TITLE
fix(form_state): Clearing mandatory fields

### DIFF
--- a/lib/src/ui/form_components/state/form_mandatory_state.dart
+++ b/lib/src/ui/form_components/state/form_mandatory_state.dart
@@ -30,6 +30,15 @@ mixin D2FormMandatoryState on ChangeNotifier {
     }
   }
 
+  void clearAllMandatoryFieldsSilently() {
+    mandatoryFields = [];
+  }
+
+  void clearAllMandatoryFields() {
+    clearAllMandatoryFieldsSilently();
+    notifyListeners();
+  }
+
   bool isFieldMandatory(String key) {
     return mandatoryFields.contains(key);
   }

--- a/lib/src/ui/form_components/state/tracker/program_rule_engine_state.dart
+++ b/lib/src/ui/form_components/state/tracker/program_rule_engine_state.dart
@@ -30,6 +30,7 @@ mixin ProgramRuleEngineState
   // TODO find a better way for clearing state
   void clearHiddenStatesSilently() {
     clearHiddenFieldsSilently();
+    clearAllMandatoryFieldsSilently();
   }
 
   void spawnProgramRuleEngine(List<String> inputFieldIds) async {


### PR DESCRIPTION
This pull request includes changes to the `form_components` state management to enhance the handling of mandatory fields. The most important changes include the addition of methods to clear mandatory fields and the integration of these methods into the program rule engine state.

Enhancements to mandatory field handling:

* [`lib/src/ui/form_components/state/form_mandatory_state.dart`](diffhunk://#diff-e097b548ab2a14c86547504671134eedadf2728f9438b6c0ebf5e1270b9ffdb8R33-R41): Added `clearAllMandatoryFieldsSilently` and `clearAllMandatoryFields` methods to clear mandatory fields, with the latter also notifying listeners.

Integration with program rule engine state:

* [`lib/src/ui/form_components/state/tracker/program_rule_engine_state.dart`](diffhunk://#diff-7e4c28ef09be6c42b20daaace8f8e32aefbe3c153e35613aec9efb6f0ee3c5e2R33): Modified `clearHiddenStatesSilently` method to also clear all mandatory fields silently.