### PR TITLE
fix(data_sets): ensured that timelyDays is handled well

### DIFF
--- a/lib/src/models/metadata/data_set.dart
+++ b/lib/src/models/metadata/data_set.dart
@@ -65,7 +65,9 @@ class D2DataSet extends D2MetaResource {
         code = json['code'],
         periodType = json['periodType'],
         expiryDays = json['expiryDays'],
-        timelyDays = json['timelyDays'],
+        timelyDays = (json['timelyDays'] is double)
+            ? json['timelyDays'].toInt()
+            : json['timelyDays'],
         openFuturePeriods = json['openFuturePeriods'],
         openPeriodsAfterCoEndDate = json['openPeriodsAfterCoEndDate'],
         shortName = json['shortName'] {


### PR DESCRIPTION
This pull request includes a change to the `D2DataSet` class in the `lib/src/models/metadata/data_set.dart` file. The change ensures that the `timelyDays` property is always an integer, even if the JSON input provides it as a double.

* [`lib/src/models/metadata/data_set.dart`](diffhunk://#diff-9e9cbc7f9873f4cb31b209c204c52ecbd87fe8acd8bc30e32f7e6f8a7158356dL68-R70): Modified the `timelyDays` assignment to convert a double to an integer if necessary.