### PR TITLE
fix(metadata_download): ensure download controller closes properly

### DIFF
--- a/lib/src/repositories/metadata/download_mixins/base_meta_download_mixin.dart
+++ b/lib/src/repositories/metadata/download_mixins/base_meta_download_mixin.dart
@@ -114,7 +114,7 @@ mixin BaseMetaDownloadServiceMixin<T extends D2MetaResource>
         downloadController.add(status.increment());
       }
       downloadController.add(status.complete());
-      downloadController.close();
+     await downloadController.close();
     } catch (e) {
       downloadController.addError(e);
       rethrow;

--- a/lib/src/repositories/metadata/download_mixins/base_single_meta_download_mixin.dart
+++ b/lib/src/repositories/metadata/download_mixins/base_single_meta_download_mixin.dart
@@ -73,6 +73,6 @@ mixin BaseSingleMetaDownloadServiceMixin<T extends D2MetaResource>
     box.put(entity);
     status.increment();
     downloadController.add(status.complete());
-    downloadController.close();
+    await downloadController.close();
   }
 }

--- a/lib/src/repositories/metadata/download_mixins/data_set_download_mixin.dart
+++ b/lib/src/repositories/metadata/download_mixins/data_set_download_mixin.dart
@@ -121,7 +121,7 @@ mixin D2DataSetDownloadServiceMixin on BaseMetaDownloadServiceMixin<D2DataSet> {
         downloadController.add(status.increment());
       }
       downloadController.add(status.complete());
-      downloadController.close();
+      await downloadController.close();
     } catch (e) {
       downloadController.addError(e);
       rethrow;

--- a/lib/src/repositories/metadata/download_mixins/program_download_mixin.dart
+++ b/lib/src/repositories/metadata/download_mixins/program_download_mixin.dart
@@ -212,7 +212,7 @@ mixin D2ProgramDownloadServiceMixin on BaseMetaDownloadServiceMixin<D2Program> {
         }
       }
       downloadController.add(status.complete());
-      downloadController.close();
+      await downloadController.close();
     } catch (e) {
       downloadController.addError(e);
       rethrow;


### PR DESCRIPTION
Ensured that the `downloadController.close()` method is awaited in metadata download mixins. This change addresses potential issues with the stream controller not closing correctly, which could lead to resource leaks or unexpected behavior.