### PR TITLE
feature/relative-periods

### DIFF
--- a/lib/src/ui/period/period_filter.dart
+++ b/lib/src/ui/period/period_filter.dart
@@ -179,7 +179,8 @@ class _PeriodSelectorState extends State<D2PeriodSelector>
         case D2PeriodTypeCategory.relative:
           _selectedPeriodType = !shouldPresetInitial
               ? _selectedPeriodType
-              : validRelativePeriodTypes.first['id'];
+              : widget.onlyAllowPeriodTypes?.first ??
+                  validRelativePeriodTypes.first['id'];
           _start = null;
           _end = null;
           break;

--- a/lib/src/utils/period_engine/constants/relative_period_types.dart
+++ b/lib/src/utils/period_engine/constants/relative_period_types.dart
@@ -3,6 +3,8 @@
 
 library;
 
+import 'package:dart_date/dart_date.dart';
+
 import 'period_categories.dart';
 import 'period_types.dart';
 
@@ -203,3 +205,254 @@ getYearsPeriodType() => [
       {"id": 'LAST_5_YEARS', "name": 'Last 5 years'},
       {"id": 'LAST_10_YEARS', "name": 'Last 10 years'},
     ];
+
+Interval? getIntervalForRelativePeriod(String id, {DateTime? reference}) {
+  final now = reference ?? DateTime.now();
+  switch (id) {
+    case 'TODAY':
+      return Interval(now.startOfDay, now.endOfDay);
+
+    case 'YESTERDAY':
+      final yesterday = now.subtract(const Duration(days: 1));
+      return Interval(yesterday.startOfDay, yesterday.endOfDay);
+
+    case 'LAST_3_DAYS':
+      final start3 = now.subtract(const Duration(days: 2)).startOfDay;
+      return Interval(start3, now.endOfDay);
+
+    case 'LAST_7_DAYS':
+      final start = now.subtract(const Duration(days: 6)).startOfDay;
+      final end = now.endOfDay;
+      return Interval(start, end);
+
+    case 'LAST_14_DAYS':
+      final start14 = now.subtract(const Duration(days: 13)).startOfDay;
+      return Interval(start14, now.endOfDay);
+
+    case 'LAST_30_DAYS':
+      final start30 = now.subtract(const Duration(days: 29)).startOfDay;
+      return Interval(start30, now.endOfDay);
+
+    case 'LAST_60_DAYS':
+      final start60 = now.subtract(const Duration(days: 59)).startOfDay;
+      return Interval(start60, now.endOfDay);
+
+    case 'LAST_90_DAYS':
+      final start90 = now.subtract(const Duration(days: 89)).startOfDay;
+      return Interval(start90, now.endOfDay);
+
+    case 'LAST_180_DAYS':
+      final start180 = now.subtract(const Duration(days: 179)).startOfDay;
+      return Interval(start180, now.endOfDay);
+
+    case 'THIS_WEEK':
+      return Interval(now.startOfWeek, now.endOfWeek);
+
+    case 'LAST_WEEK':
+      final lastWeek = now.subtract(const Duration(days: 7));
+      return Interval(lastWeek.startOfWeek, lastWeek.endOfWeek);
+
+    case 'LAST_4_WEEKS':
+      final start = now.subtract(const Duration(days: 7 * 3)).startOfWeek;
+      return Interval(start, now.endOfWeek);
+
+    case 'LAST_12_WEEKS':
+      final start = now.subtract(const Duration(days: 7 * 11)).startOfWeek;
+      return Interval(start, now.endOfWeek);
+
+    case 'LAST_52_WEEKS':
+      final start = now.subtract(const Duration(days: 7 * 51)).startOfWeek;
+      return Interval(start, now.endOfWeek);
+
+    case 'WEEKS_THIS_YEAR':
+      final start = DateTime(now.year, 1, 1).startOfWeek;
+      return Interval(start, now.endOfWeek);
+
+    case 'THIS_BIWEEK':
+      final isFirstBiweek = now.difference(now.startOfWeek).inDays < 7;
+      final start = isFirstBiweek
+          ? now.startOfWeek
+          : now.startOfWeek.subtract(const Duration(days: 7));
+      final end = start.add(const Duration(days: 13)).endOfDay;
+      return Interval(start, end);
+
+    case 'LAST_BIWEEK':
+      final isFirstBiweek = now.difference(now.startOfWeek).inDays < 7;
+      final end = isFirstBiweek
+          ? now.startOfWeek.subtract(const Duration(days: 1)).endOfDay
+          : now.startOfWeek.subtract(const Duration(days: 8)).endOfDay;
+      final start = end.subtract(const Duration(days: 13)).startOfDay;
+      return Interval(start, end);
+
+    case 'LAST_4_BIWEEKS':
+      final isFirstBiweek = now.difference(now.startOfWeek).inDays < 7;
+      final end = isFirstBiweek
+          ? now.startOfWeek.subtract(const Duration(days: 1)).endOfDay
+          : now.startOfWeek.subtract(const Duration(days: 8)).endOfDay;
+      final start = end.subtract(const Duration(days: 13 * 4 - 1)).startOfDay;
+      return Interval(start, end);
+
+    case 'THIS_MONTH':
+      return Interval(now.startOfMonth, now.endOfMonth);
+
+    case 'LAST_MONTH':
+      final lastMonth = DateTime(now.year, now.month - 1);
+      return Interval(lastMonth.startOfMonth, lastMonth.endOfMonth);
+
+    case 'LAST_3_MONTHS':
+      final start = DateTime(now.year, now.month - 2).startOfMonth;
+      return Interval(start, now.endOfMonth);
+
+    case 'LAST_6_MONTHS':
+      final start = DateTime(now.year, now.month - 5).startOfMonth;
+      return Interval(start, now.endOfMonth);
+
+    case 'LAST_12_MONTHS':
+      final start = DateTime(now.year, now.month - 11).startOfMonth;
+      return Interval(start, now.endOfMonth);
+
+    case 'MONTHS_THIS_YEAR':
+      final start = DateTime(now.year, 1, 1).startOfMonth;
+      return Interval(start, now.endOfMonth);
+
+    case 'THIS_BIMONTH':
+      final biMonthStartMonth =
+          (now.month % 2 == 0) ? now.month - 1 : now.month;
+      final start = DateTime(now.year, biMonthStartMonth).startOfMonth;
+      final end = DateTime(now.year, biMonthStartMonth + 1).endOfMonth;
+      return Interval(start, end);
+
+    case 'LAST_BIMONTH':
+      final thisBiMonthStartMonth =
+          (now.month % 2 == 0) ? now.month - 1 : now.month;
+      final lastBiMonthStartMonth = thisBiMonthStartMonth - 2;
+      final adjustedYear = now.year - (lastBiMonthStartMonth < 1 ? 1 : 0);
+      final startMonth = (lastBiMonthStartMonth < 1)
+          ? 12 + lastBiMonthStartMonth
+          : lastBiMonthStartMonth;
+      final start = DateTime(adjustedYear, startMonth).startOfMonth;
+      final end = DateTime(adjustedYear, startMonth + 1).endOfMonth;
+      return Interval(start, end);
+
+    case 'LAST_6_BIMONTHS':
+      final thisBiMonthStartMonth =
+          (now.month % 2 == 0) ? now.month - 1 : now.month;
+      final startMonth = thisBiMonthStartMonth - (2 * 5);
+      final adjustedStartYear =
+          now.year - ((startMonth < 1) ? ((-startMonth + 1) ~/ 12 + 1) : 0);
+      final normalizedStartMonth =
+          (startMonth < 1) ? 12 + (startMonth % 12) : startMonth;
+      final start =
+          DateTime(adjustedStartYear, normalizedStartMonth).startOfMonth;
+      final end = DateTime(now.year, thisBiMonthStartMonth + 1).endOfMonth;
+      return Interval(start, end);
+
+    case 'BIMONTHS_THIS_YEAR':
+      final start = DateTime(now.year, 1).startOfMonth;
+      final end = now.endOfMonth;
+      return Interval(start, end);
+
+    case 'THIS_QUARTER':
+      final currentQuarter = ((now.month - 1) ~/ 3) + 1;
+      final startMonth = (currentQuarter - 1) * 3 + 1;
+      final start = DateTime(now.year, startMonth).startOfMonth;
+      final end = DateTime(now.year, startMonth + 2).endOfMonth;
+      return Interval(start, end);
+
+    case 'LAST_QUARTER':
+      final currentQuarter = ((now.month - 1) ~/ 3) + 1;
+      int lastQuarter = currentQuarter - 1;
+      int year = now.year;
+      if (lastQuarter < 1) {
+        lastQuarter = 4;
+        year -= 1;
+      }
+      final startMonth = (lastQuarter - 1) * 3 + 1;
+      final start = DateTime(year, startMonth).startOfMonth;
+      final end = DateTime(year, startMonth + 2).endOfMonth;
+      return Interval(start, end);
+
+    case 'LAST_4_QUARTERS':
+      final currentQuarter = ((now.month - 1) ~/ 3) + 1;
+      final startQuarter = currentQuarter - 3;
+      int startYear = now.year;
+      int startQuarterAdjusted = startQuarter;
+      if (startQuarter < 1) {
+        startYear -= 1;
+        startQuarterAdjusted = 4 + startQuarter;
+      }
+      final startMonth = (startQuarterAdjusted - 1) * 3 + 1;
+      final start = DateTime(startYear, startMonth).startOfMonth;
+      final endQuarterMonth = (currentQuarter - 1) * 3 + 3;
+      final end = DateTime(now.year, endQuarterMonth).endOfMonth;
+      return Interval(start, end);
+
+    case 'QUARTERS_THIS_YEAR':
+      final start = DateTime(now.year, 1).startOfMonth;
+      final end = now.endOfMonth;
+      return Interval(start, end);
+
+    case 'THIS_SIX_MONTH':
+      final half = (now.month <= 6) ? 1 : 2;
+      final startMonth = (half == 1) ? 1 : 7;
+      final start = DateTime(now.year, startMonth).startOfMonth;
+      final end = DateTime(now.year, startMonth + 5).endOfMonth;
+      return Interval(start, end);
+
+    case 'LAST_SIX_MONTH':
+      final half = (now.month <= 6) ? 1 : 2;
+      int lastHalf = half - 1;
+      int year = now.year;
+      if (lastHalf < 1) {
+        lastHalf = 2;
+        year -= 1;
+      }
+      final startMonth = (lastHalf == 1) ? 1 : 7;
+      final start = DateTime(year, startMonth).startOfMonth;
+      final end = DateTime(year, startMonth + 5).endOfMonth;
+      return Interval(start, end);
+
+    case 'LAST_2_SIXMONTHS':
+      final half = (now.month <= 6) ? 1 : 2;
+      int startHalf = half - 1;
+      int startYear = now.year;
+      if (startHalf < 1) {
+        startHalf = 2;
+        startYear -= 1;
+      }
+      final startMonth = (startHalf == 1) ? 1 : 7;
+      final start = DateTime(startYear, startMonth).startOfMonth;
+      final endMonth = (half == 1) ? 6 : 12;
+      final end = DateTime(now.year, endMonth).endOfMonth;
+      return Interval(start, end);
+
+    case 'THIS_FINANCIAL_YEAR':
+      return Interval(now.startOfYear, now.endOfYear);
+
+    case 'LAST_FINANCIAL_YEAR':
+      final lastYear = DateTime(now.year - 1);
+      return Interval(lastYear.startOfYear, lastYear.endOfYear);
+
+    case 'LAST_5_FINANCIAL_YEARS':
+      final start = DateTime(now.year - 4).startOfYear;
+      return Interval(start, now.endOfYear);
+
+    case 'THIS_YEAR':
+      return Interval(now.startOfYear, now.endOfYear);
+
+    case 'LAST_YEAR':
+      final lastYear = DateTime(now.year - 1);
+      return Interval(lastYear.startOfYear, lastYear.endOfYear);
+
+    case 'LAST_5_YEARS':
+      final start5 = DateTime(now.year - 4).startOfYear;
+      return Interval(start5, now.endOfYear);
+
+    case 'LAST_10_YEARS':
+      final start10 = DateTime(now.year - 9).startOfYear;
+      return Interval(start10, now.endOfYear);
+
+    default:
+      return null;
+  }
+}

--- a/lib/src/utils/period_engine/models/period.dart
+++ b/lib/src/utils/period_engine/models/period.dart
@@ -38,12 +38,15 @@ class D2Period {
 
   ///`D2Period.fromObject` is a constructor method that creates a D2Period from a `Map` object.
   ///The constructor accepts a `Map<String, dynamic>` object, `String` period type and  `String` period category as required parameters
-  D2Period.fromObject(Map<String, dynamic> object,
-      {required this.type, required this.category}) {
+  D2Period.fromObject(
+      Map<String, dynamic> object, Interval? interval, {
+        required this.type,
+        required this.category,
+      }) {
+    start = interval?.start;
+    end = interval?.end;
     id = object['id'];
     name = object['name'];
-    start = null;
-    end = null;
   }
 
   ///`D2Period.fromInterval` is a constructor function that generates period based on the passed `interval`, `idGenerator` function, `nameGenerator` function, `String` period type and  `String` period category as required parameters

--- a/lib/src/utils/period_engine/models/period_type.dart
+++ b/lib/src/utils/period_engine/models/period_type.dart
@@ -140,12 +140,17 @@ class D2PeriodType {
   }
 
   ///  This is a private method for getting relative periods
-  _getRelativePeriods(Map<String, dynamic> object) {
-    List<Map<String, dynamic>> periodObject = object['getPeriods']() ?? [];
-    return periodObject
-        .map((periodObject) =>
-            D2Period.fromObject(periodObject, type: id, category: category))
-        .toList();
+  _getRelativePeriods(Map<String, dynamic> object)  {
+    final periodObjects = object['getPeriods']() ?? [];
+    return periodObjects.map<D2Period>((period) {
+      final interval = getIntervalForRelativePeriod(period['id']);
+      return D2Period.fromObject(
+        period,
+        interval,
+        type: object['id'],
+        category: object['category'],
+      );
+    }).toList();
   }
 
   /// This is a static method for getting a period from the period types by using the period id


### PR DESCRIPTION
This PR introduces a new feature `getIntervalForRelativePeriod` within `relative_period_types.dart`.

This function takes a relative period ID (e.g., 'TODAY', 'LAST_WEEK') and an optional reference `DateTime` (defaults to `DateTime.now()`) and returns a `dart_date.Interval` object representing the date range for that relative period.

This utility function simplifies the process of obtaining date intervals for various relative period types, making it easier to work with date ranges in period-related calculations.