### PR TITLE
Update flutter SDK and dependency versions

### DIFF
--- a/lib/src/services/sync/on_saving_synchronizations/foreground_task_handler.dart
+++ b/lib/src/services/sync/on_saving_synchronizations/foreground_task_handler.dart
@@ -34,7 +34,7 @@ class OfflineVisitsTaskHandler extends TaskHandler {
 
   // Called when the task is destroyed.
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
     FlutterForegroundTask.sendDataToMain({"onDestroyFromBadge": true});
     FlutterForegroundTask.stopService();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,12 @@ description: A collection of tools and utilities for interacting with DHIS2 auth
 version: 0.0.58
 homepage: null
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.10.0-0 <4.0.0"
+  flutter: ">=3.38.0"
 dependencies:
   collection: ^1.18.0
-  connectivity_plus: ^6.1.5
-  fluttertoast: ^8.2.4
+  connectivity_plus: ^7.0.0
+  fluttertoast: ^9.0.0
   dart_date: ^1.3.2
   dhis2_flutter_ui: ^1.1.9
   flutter:
@@ -16,24 +16,24 @@ dependencies:
   flutter_secure_storage: ^9.0.0
   flutter_svg: ^2.0.10+1
   http: ^1.3.0
-  objectbox: ^4.3.0
+  objectbox: ^5.0.2
   objectbox_flutter_libs: any
   path_provider: ^2.1.2
   provider: ^6.1.2
-  syncfusion_flutter_datepicker: ^26.2.14
+  syncfusion_flutter_datepicker: ^31.2.10
   path: any
   animated_tree_view: ^2.2.1
-  geolocator: ^11.0.0
-  flutter_map: ^6.1.0
-  intl: ^0.19.0
+  geolocator: ^12.0.0
+  flutter_map: ^7.0.2
+  intl: ^0.20.2
   barcode_scan2: ^4.5.0
-  flutter_foreground_task: ^8.17.0
+  flutter_foreground_task: ^9.1.0
   dropdown_search: ^6.0.1
-  permission_handler: ^11.4.0
+  permission_handler: ^12.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
-  objectbox_generator: ^4.0.3
+  flutter_lints: ^6.0.0
+  objectbox_generator: ^5.0.2
   build_runner: ^2.4.8
 flutter: null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dhis2_flutter_toolkit
 description: A collection of tools and utilities for interacting with DHIS2 authentication, Metadata, and Tracker data
-version: 0.0.58
+version: 0.0.59
 homepage: null
 environment:
   sdk: ">=3.10.0-0 <4.0.0"


### PR DESCRIPTION
- Updated flutter SDK and dependency versions
- Added `bool isTimeout` prop to the `onDestroy()` function as required by the `flutter_foreground_task` after the dependency upgrade